### PR TITLE
Assign User Agent and x-looker-appid headers in Looker JDBC Driver

### DIFF
--- a/core/src/main/java/org/apache/calcite/avatica/remote/looker/LookerSdkFactory.java
+++ b/core/src/main/java/org/apache/calcite/avatica/remote/looker/LookerSdkFactory.java
@@ -24,6 +24,7 @@ import com.looker.rtl.SDKResponse;
 import com.looker.rtl.Transport;
 import com.looker.rtl.TransportKt;
 import com.looker.sdk.ApiSettings;
+import com.looker.sdk.Constants;
 import com.looker.sdk.LookerSDK;
 
 import java.sql.SQLException;
@@ -48,6 +49,8 @@ public class LookerSdkFactory {
 
   private static final String RESULT_FORMAT = "json_bi";
   private static final String QUERY_ENDPOINT = "/api/4.0/sql_interface_queries/%s/run/%s";
+  private static final String DRIVER_USER_AGENT = "looker-jdbc-driver-1.24.1";
+  private static final String USER_AGENT_STRING = "User-Agent";
 
   /**
    * 1 hour in seconds. This is not configurable.
@@ -125,12 +128,15 @@ public class LookerSdkFactory {
 
     ConfigurationProvider finalizedConfig = ApiSettings.fromMap(apiConfig);
 
+    // assign values for user agent and x-looker-appid headers and add to session
     String userAgent = props.get("userAgent");
-    if (userAgent != null) {
-      Map<String, String> headers = finalizedConfig.getHeaders();
-      headers.put("User-Agent", props.get("userAgent"));
-      finalizedConfig.setHeaders(headers);
+    if (userAgent == null) {
+      userAgent = DRIVER_USER_AGENT;
     }
+    Map<String, String> headers = finalizedConfig.getHeaders();
+    headers.put(USER_AGENT_STRING, userAgent);
+    headers.put(Constants.LOOKER_APPID, DRIVER_USER_AGENT);
+    finalizedConfig.setHeaders(headers);
 
     AuthSession session = new AuthSession(finalizedConfig, new Transport(finalizedConfig));
 

--- a/looker.md
+++ b/looker.md
@@ -64,7 +64,9 @@ You should make it from a branch that differs from Avatica's
 
 In Avatica's `gradle.properties`, update the value of
 `calcite.avatica.version` to the release name (something like
-`1.22.1-looker`) and commit.
+`1.22.1-looker`). Additionally, update the `DRIVER_USER_AGENT` property string
+in [LookerSdkFactory](core/src/main/java/org/apache/calcite/avatica/remote/looker/LookerSdkFactory.java)
+to point to the same build version and commit.
 
 Define Looker's Nexus repository in your `~/.gradle/init.gradle.kts`
 file:


### PR DESCRIPTION
Fixes b/343254086 (refer for additional context).

Verified this change using sqlline with the updated driver jar, request headers included assigned values.

<img width="631" alt="image" src="https://github.com/looker-open-source/calcite-avatica/assets/12583553/c958a1f4-c846-4c94-9abc-7942b8c8b46f">
