### PR TITLE
Disable inconsistent DST/Ansi/Gregorian timestamp conversion tests

### DIFF
--- a/core/src/test/java/org/apache/calcite/avatica/AvaticaResultSetConversionsTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/AvaticaResultSetConversionsTest.java
@@ -704,7 +704,8 @@ public class AvaticaResultSetConversionsTest {
       Array expectedArray =
           new ArrayFactoryImpl(DateTimeUtils.DEFAULT_ZONE).createArray(
               intType, Arrays.asList(123, 18234));
-      assertTrue(ArrayImpl.equalContents(expectedArray, g.getArray(resultSet)));
+      // b/344910002: disable inconsistent timezone timestamp test
+      // assertTrue(ArrayImpl.equalContents(expectedArray, g.getArray(resultSet)));
     }
   }
 
@@ -1054,7 +1055,8 @@ public class AvaticaResultSetConversionsTest {
     }
 
     @Override public void testGetString(ResultSet resultSet) throws SQLException {
-      assertEquals(DST_DATE_STRING, g.getString(resultSet));
+      // b/344910002: disable inconsistent timezone timestamp test
+      // assertEquals(DST_DATE_STRING, g.getString(resultSet));
     }
 
     @Override public void testGetBoolean(ResultSet resultSet) throws SQLException {
@@ -1139,7 +1141,8 @@ public class AvaticaResultSetConversionsTest {
     }
 
     @Override public void testGetString(ResultSet resultSet) throws SQLException {
-      assertEquals(DST_TIMESTAMP_STRING, g.getString(resultSet)); // Maybe delete
+      // b/344910002: disable inconsistent DST timestamp test
+      // assertEquals(DST_TIMESTAMP_STRING, g.getString(resultSet)); // Maybe delete
       assertEquals(expectedString, g.getString(resultSet));
     }
 

--- a/core/src/test/java/org/apache/calcite/avatica/util/TimestampWithLocalTimeZoneAccessorTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/util/TimestampWithLocalTimeZoneAccessorTest.java
@@ -206,8 +206,11 @@ public class TimestampWithLocalTimeZoneAccessorTest {
 
     value = new Timestamp(SHIFT_INSTANT_1);
     assertThat(instance.getString(), is(SHIFT_STRING_1));
-    value = new Timestamp(SHIFT_INSTANT_2);
-    assertThat(instance.getString(), is(SHIFT_STRING_2));
+
+    // b/344910002: disable inconsistent Gregorian shift test
+    // value = new Timestamp(SHIFT_INSTANT_2);
+    // assertThat(instance.getString(), is(SHIFT_STRING_2));
+
     value = new Timestamp(SHIFT_INSTANT_3);
     assertThat(instance.getString(), is(SHIFT_STRING_3));
     value = new Timestamp(SHIFT_INSTANT_4);

--- a/core/src/test/java/org/apache/calcite/avatica/util/TimestampWithLocalTimeZoneFromNumberAccessorTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/util/TimestampWithLocalTimeZoneFromNumberAccessorTest.java
@@ -17,6 +17,7 @@
 package org.apache.calcite.avatica.util;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.sql.Date;
@@ -281,21 +282,23 @@ public class TimestampWithLocalTimeZoneFromNumberAccessorTest {
   /**
    * Test {@code getTimestamp()} supports date range 0001-01-01 to 9999-12-31 required by ANSI SQL.
    */
+  // b/344910002: disable inconsistent ANSI timestamp format test
+  @Ignore
   @Test public void testTimestampWithAnsiDateRange() throws SQLException {
     for (int i = 1; i < 1943; ++i) {
-      assertTimestamp(i,  TimeZone.getDefault().getRawOffset());
+      assertTimestamp(i, TimeZone.getDefault().getRawOffset());
     }
     for (int i = 1943; i < 1946; ++i) {
-      assertTimestamp(i,  TimeZone.getDefault().getRawOffset() + DateTimeUtils.MILLIS_PER_HOUR);
+      assertTimestamp(i, TimeZone.getDefault().getRawOffset() + DateTimeUtils.MILLIS_PER_HOUR);
     }
     for (int i = 1946; i < 1949; ++i) {
-      assertTimestamp(i,  TimeZone.getDefault().getRawOffset());
+      assertTimestamp(i, TimeZone.getDefault().getRawOffset());
     }
     for (int i = 1949; i < 1950; ++i) {
-      assertTimestamp(i,  TimeZone.getDefault().getRawOffset() + DateTimeUtils.MILLIS_PER_HOUR);
+      assertTimestamp(i, TimeZone.getDefault().getRawOffset() + DateTimeUtils.MILLIS_PER_HOUR);
     }
     for (int i = 1950; i < 10000; ++i) {
-      assertTimestamp(i,  TimeZone.getDefault().getRawOffset());
+      assertTimestamp(i, TimeZone.getDefault().getRawOffset());
     }
   }
 

--- a/core/src/test/java/org/apache/calcite/avatica/util/TimestampWithLocalTimeZoneFromUtilDateAccessorTest.java
+++ b/core/src/test/java/org/apache/calcite/avatica/util/TimestampWithLocalTimeZoneFromUtilDateAccessorTest.java
@@ -208,8 +208,11 @@ public class TimestampWithLocalTimeZoneFromUtilDateAccessorTest {
   @Test public void testStringWithGregorianShift() throws SQLException {
     value = new Timestamp(SHIFT_INSTANT_1);
     assertThat(instance.getString(), is(SHIFT_OFFSET_STRING_1));
-    value = new Timestamp(SHIFT_INSTANT_2);
-    assertThat(instance.getString(), is(SHIFT_OFFSET_STRING_2));
+
+    // b/344910002: disable inconsistent Gregorian shift test
+    // value = new Timestamp(SHIFT_INSTANT_2);
+    // assertThat(instance.getString(), is(SHIFT_OFFSET_STRING_2));
+
     value = new Timestamp(SHIFT_INSTANT_3);
     assertThat(instance.getString(), is(SHIFT_OFFSET_STRING_3));
     value = new Timestamp(SHIFT_INSTANT_4);


### PR DESCRIPTION
DST = Daylight Savings Time
Ansi = Ansi SQL timestamp format
Gregorian = Gregorian calendar date shift

Fixes: b/344910002 (refer for additional context)

NOTE: The one failing one CI job can be considered inconsequential and fixed later, it is from a calcite test where the exception message thrown has a typo/repetition.