### PR TITLE
Modify Calcite build CI job to use looker-open-source fork instead of apache main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,7 @@ jobs:
         ./gradlew publishToMavenLocal -Pcalcite.avatica.version=1.0.0-dev-main -PskipJavadoc
     - name: 'Test Calcite'
       run: |
-        git clone --depth 100 https://github.com/apache/calcite.git ../calcite
+        git clone -b looker --single-branch --depth 100 https://github.com/looker-open-source/calcite.git ../calcite
         cd ../calcite
         ./gradlew --no-parallel --no-daemon build -Pcalcite.avatica.version=1.0.0-dev-main-SNAPSHOT -PenableMavenLocal
 


### PR DESCRIPTION
Resolved missing classes issues with Ci job that was building against calcite main instead of the looker fork.

Associated with b/344910002 (refer for additional context)

